### PR TITLE
Implement requiresMainQueueSetup to prevent warning in RN 0.49+.

### DIFF
--- a/ios/RCTAlipay.m
+++ b/ios/RCTAlipay.m
@@ -30,6 +30,10 @@ static NSString *const kOpenURLNotification = @"RCTOpenURLNotification";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 - (void)handleOpenURL:(NSNotification *)notification {
     NSString *urlString = notification.userInfo[@"url"];
     NSURL *url = [NSURL URLWithString:urlString];


### PR DESCRIPTION
react-native 0.49+ generates a warning:

> Module RCTAlipay requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release React Native will default 
to initializing all native modules on a background thread unless explicitly opted-out of.